### PR TITLE
clang-format, make sure only a single thread is sending data to flps …

### DIFF
--- a/examples/SCHEDULER-FLP-EPN/Message.h
+++ b/examples/SCHEDULER-FLP-EPN/Message.h
@@ -6,19 +6,27 @@
 #include <string>
 #include <vector>
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
+struct EPNtoScheduler {
+  int Id;
+  uint64_t freeSlots;
+  uint64_t numEPNs;
+};
+struct SchedulerToFLP {
+  int IdForFirstEpn;
+  int IdForSecondEpn;
+  int IdForThirdEpn;
+};
+struct FLPtoEPN {
+  int IdOfFlp;
+  unsigned long sTF;
+  int schedNum;
+};
 
-
-       struct EPNtoScheduler{int Id; uint64_t freeSlots; uint64_t numEPNs;};
-       struct SchedulerToFLP{int IdForFirstEpn; int IdForSecondEpn; int IdForThirdEpn;};
-       struct FLPtoEPN{int IdOfFlp; unsigned long sTF; int schedNum;};
-
-       struct SchedFLPTest{int IdForFirst;};
-
-
+struct SchedFLPTest {
+  int IdForFirst;
+};
 }
-
 
 #endif

--- a/examples/SCHEDULER-FLP-EPN/conf_gen.rb
+++ b/examples/SCHEDULER-FLP-EPN/conf_gen.rb
@@ -128,8 +128,6 @@ sched_dev[:channels] << sched_epn_chan
 
 
 
-
-
 ###################
 FLP_DATA_PORT = 20000
 flp_port_per_node = {} # track used data ports on each flp node
@@ -170,7 +168,7 @@ NUM_FLP.times do | flp |
   flp_sched_socket = Marshal.load(Marshal.dump(SOCKET_HASH))
   flp_sched_socket[:type] = "pull"
   flp_sched_socket[:method] = "connect"
-  flp_sched_socket[:address] = "tcp://#{SCHED_NODE}:#{SCHED_FLP_PORT + flp}"
+  flp_sched_socket[:address] = "tcp://#{SCHED_NODE}ib0:#{SCHED_FLP_PORT + flp}"
 
   flp_sched_chan[:sockets] << flp_sched_socket
   flp_dev[:channels] << flp_sched_chan
@@ -204,7 +202,7 @@ NUM_EPN.times do | epn |
     flp_socket = Marshal.load(Marshal.dump(SOCKET_HASH))
     flp_socket[:type] = "pull"
     flp_socket[:method] = "connect"
-    flp_socket[:address] = "tcp://#{flp_node_map[flp][:node]}:#{flp_node_map[flp][:data_ports][epn]}"
+    flp_socket[:address] = "tcp://#{flp_node_map[flp][:node]}ib0:#{flp_node_map[flp][:data_ports][epn]}"
     # flp_config[flp][:channels][0][:sockets][epn][:address]
 
     epn_data_chan[:sockets] << flp_socket
@@ -217,7 +215,7 @@ NUM_EPN.times do | epn |
   epn_sched_socket = Marshal.load(Marshal.dump(SOCKET_HASH))
   epn_sched_socket[:type] = "push"
   epn_sched_socket[:method] = "connect"
-  epn_sched_socket[:address] = "tcp://#{SCHED_NODE}:#{SCHED_EPN_PORT + epn}"
+  epn_sched_socket[:address] = "tcp://#{SCHED_NODE}ib0:#{SCHED_EPN_PORT + epn}"
 
   epn_sched_chan[:sockets] << epn_sched_socket
   epn_dev[:channels] << epn_sched_chan

--- a/examples/SCHEDULER-FLP-EPN/epn.cxx
+++ b/examples/SCHEDULER-FLP-EPN/epn.cxx
@@ -4,236 +4,193 @@
  */
 
 #include "epn.h"
-#include "FairMQPoller.h"
-#include "Message.h"
-#include <iostream>
-#include <string>
-#include <random>
-#include <thread>
 #include <time.h>
 #include <fstream>
+#include <iostream>
+#include <random>
 #include <sstream>
-
-
+#include <string>
+#include <thread>
+#include "FairMQPoller.h"
+#include "Message.h"
 
 using namespace std;
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
 epn::epn()
-    : Id(0)
-    , freeSlots(0)
-    , maxSlots()
-    , numEPNS()
-    , numFLPS(0)
-    , rcvdSTFs()
-    , it()
-    , sTF(1)
-    , procTime(30)
-    , procDev(5)
-    , startTime(0)
-    ,timeBetweenTf(0)
-    ,programTime(0)
-    ,intMs(1000)
-    ,receptionOfTf1()
-    ,processingTime1()
-    ,numberOfLostTfs1()
- 
+    : Id(0),
+      freeSlots(0),
+      maxSlots(),
+      numEPNS(),
+      numFLPS(0),
+      rcvdSTFs(),
+      it(),
+      sTF(1),
+      procTime(30),
+      procDev(5),
+      startTime(0),
+      timeBetweenTf(0),
+      programTime(0),
+      intMs(1000),
+      receptionOfTf1(),
+      processingTime1(),
+      numberOfLostTfs1()
 
-
-    {
-    static_assert(std::is_pod<EPNtoScheduler>::value==true, "my struct  is not pod");
-    }
-
-void epn::InitTask()
 {
-	timeBetweenTf=getHistKey();
-        startTime=getHistKey();
-        Id = fConfig->GetValue<uint64_t>("myId");
-        maxSlots = fConfig->GetValue<uint64_t>("maxSlots");
-        freeSlots = maxSlots;
-        numEPNS = fConfig->GetValue<uint64_t>("numEPNS");
-        numFLPS = fConfig->GetValue<uint64_t>("numFLPS");
-        programTime = fConfig->GetValue<uint64_t>("programTime");
-        programTime=programTime*60*1000;
-        std::thread th1 = senderThread(&freeSlots, &numEPNS, &Id, &startTime, &programTime);
-        th1.detach();
-
-
-    }
-
-
-bool epn::ConditionalRun()
-{
-     receive();
-     return true;
-   }
-
-
-
-
-
-
-
-uint64_t epn::getHistKey(){
-    //get the current time
-    const auto time = std::chrono::high_resolution_clock::now();
-    //get the time from THEN to now
-    auto duration = time.time_since_epoch();
-    const std::uint64_t intKey = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-    //determine the interval (key for the hist map)
-    //const std::uint64_t intKey = millis / intMs * intMs;
-    return intKey;
-
+  static_assert(std::is_pod<EPNtoScheduler>::value == true, "my struct  is not pod");
 }
 
-void epn::receive(){
-        FairMQPollerPtr poller(NewPoller("data"));
-        poller->Poll(100);
+void epn::InitTask() {
+  timeBetweenTf = getHistKey();
+  startTime = getHistKey();
+  Id = fConfig->GetValue<uint64_t>("myId");
+  maxSlots = fConfig->GetValue<uint64_t>("maxSlots");
+  freeSlots = maxSlots;
+  numEPNS = fConfig->GetValue<uint64_t>("numEPNS");
+  numFLPS = fConfig->GetValue<uint64_t>("numFLPS");
+  programTime = fConfig->GetValue<uint64_t>("programTime");
+  programTime = programTime * 60 * 1000;
+  std::thread th1 = senderThread(&freeSlots, &numEPNS, &Id, &startTime, &programTime);
+  th1.detach();
+}
 
+bool epn::ConditionalRun() {
+  receive();
+  return true;
+}
 
-        for(uint64_t i=0; i<numFLPS; i++){
+uint64_t epn::getHistKey() {
+  // get the current time
+  const auto time = std::chrono::high_resolution_clock::now();
+  // get the time from THEN to now
+  auto duration = time.time_since_epoch();
+  const std::uint64_t intKey = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  // determine the interval (key for the hist map)
+  // const std::uint64_t intKey = millis / intMs * intMs;
+  return intKey;
+}
 
-          if (!poller->CheckInput("data", i)) {
-            continue;
-          }
+void epn::receive() {
+  FairMQPollerPtr poller(NewPoller("data"));
+  poller->Poll(100);
 
-          auto &myRecvChan = GetChannel("data", i);
+  for (uint64_t i = 0; i < numFLPS; i++) {
+    if (!poller->CheckInput("data", i)) {
+      continue;
+    }
 
-          FLPtoEPN messagei;
+    auto &myRecvChan = GetChannel("data", i);
 
-          FairMQMessagePtr aMessage = myRecvChan.NewMessage();
+    FLPtoEPN messagei;
 
-          if (sizeof(FLPtoEPN) != myRecvChan.Receive(aMessage)) {
-            LOG(ERROR) << "Bad Message from FLP" << i+1;
-            continue;
-          }
+    FairMQMessagePtr aMessage = myRecvChan.NewMessage();
 
-          std::memcpy(&messagei, aMessage->GetData(), sizeof(FLPtoEPN));
+    if (sizeof(FLPtoEPN) != myRecvChan.Receive(aMessage)) {
+      LOG(ERROR) << "Bad Message from FLP" << i + 1;
+      continue;
+    }
 
-          if (messagei.IdOfFlp != (i+1)) {
-            LOG(ERROR) << "Bad Message ID from FLP" << i+1 << " != " << messagei.IdOfFlp;
-            continue;
-          }
-	  if(messagei.sTF==1&&messagei.schedNum==-1){
-		 ofstream receptionOfTf, processingTime, numberOfLostTfs;
+    std::memcpy(&messagei, aMessage->GetData(), sizeof(FLPtoEPN));
 
-     		 receptionOfTf.open("TimebetweenReceptionOfTf.txt."+to_string(Id), std::ios_base::app);
-     		 processingTime.open("processingTime.txt."+to_string(Id), std::ios_base::app);
-     		 //numberOfLostTfs.open("numberOfLostTfs.txt."+to_string(Id), std::ios_base::app);
-           
+    if (messagei.IdOfFlp != (i + 1)) {
+      LOG(ERROR) << "Bad Message ID from FLP" << i + 1 << " != " << messagei.IdOfFlp;
+      continue;
+    }
+    if (messagei.sTF == 1 && messagei.schedNum == -1) {
+      ofstream receptionOfTf, processingTime, numberOfLostTfs;
 
-       		 receptionOfTf<<receptionOfTf1.rdbuf();
-       		 processingTime<<processingTime1.rdbuf();
-       		 //numberOfLostTfs<<numberOfLostTfs1.rdbuf();
-        
+      receptionOfTf.open("TimebetweenReceptionOfTf.txt." + to_string(Id), std::ios_base::app);
+      processingTime.open("processingTime.txt." + to_string(Id), std::ios_base::app);
+      // numberOfLostTfs.open("numberOfLostTfs.txt."+to_string(Id),
+      // std::ios_base::app);
 
+      receptionOfTf << receptionOfTf1.rdbuf();
+      processingTime << processingTime1.rdbuf();
+      // numberOfLostTfs<<numberOfLostTfs1.rdbuf();
 
+      LOG(INFO) << "TERMINATING PROGRAM NOW!";
+      ChangeState("READY");
+      ChangeState("RESETTING_TASK");
+      ChangeState("DEVICE_READY");
+      ChangeState("RESETTING_DEVICE");
+      ChangeState("IDLE");
+      ChangeState("EXITING");
+    }
 
+    rcvdSTFs[messagei.sTF]++;
+    if (rcvdSTFs[messagei.sTF] == numFLPS) {
+      receptionOfTf1 << (getHistKey() - timeBetweenTf) << skipws << endl;
+      timeBetweenTf = getHistKey();
+      // LOG(info) << "Epn: "<< Id<<" received data from FLP number: " <<
+      // messagei.IdOfFlp << " and sTF number is "<< messagei.sTF;
+    }
+    /*
+    for( it=rcvdSTFs.begin(); it!=rcvdSTFs.end(); it++){
+      cout<< it->first<<" =>"<< it->second<<endl;
+    }
+    */
+    assert(rcvdSTFs[messagei.sTF] <= numFLPS);
 
-    		LOG(INFO)<<"TERMINATING PROGRAM NOW!";
-   	        ChangeState("READY");
-   	        ChangeState("RESETTING_TASK");
-   	        ChangeState("DEVICE_READY");
-   	        ChangeState("RESETTING_DEVICE");
-   	        ChangeState("IDLE");
-   	        ChangeState("EXITING");
-		}
-
-
-
-          rcvdSTFs[messagei.sTF]++;
-          if(rcvdSTFs[messagei.sTF] == numFLPS){
-		
-            receptionOfTf1<< (getHistKey()-timeBetweenTf) <<skipws<< endl;
-            timeBetweenTf=getHistKey();
-           // LOG(info) << "Epn: "<< Id<<" received data from FLP number: " << messagei.IdOfFlp << " and sTF number is "<< messagei.sTF;
-          }
-          /*
-          for( it=rcvdSTFs.begin(); it!=rcvdSTFs.end(); it++){
-            cout<< it->first<<" =>"<< it->second<<endl;
-          }
-          */
-          assert(rcvdSTFs[messagei.sTF] <= numFLPS);
-
-          if(rcvdSTFs[messagei.sTF] == numFLPS){
-
-           
-
-            if(freeSlots>0) {
-	      freeSlots--;
-              float x = getDelay();
-              LOG(INFO) << "Delay work for: " << x << "seconds for TFid: " << messagei.sTF << "and my ID is: " << Id<<"and this is schedule nr: "<<messagei.schedNum;
-              std::thread t3(MyDelayedFun, x, &freeSlots, &processingTime1);
-              t3.detach();
-            } else {
-              LOG(INFO)<<"INFORMATION LOST DUE TO OVERCAPACITY AND MY ID IS: "<<Id<<"AND THIS IS SCHEDULE NR.: "<<messagei.schedNum;
-	      numberOfLostTfs1<<messagei.sTF<<endl;
-              
-            }
-          }
+    if (rcvdSTFs[messagei.sTF] == numFLPS) {
+      if (freeSlots > 0) {
+        freeSlots--;
+        float x = getDelay();
+        LOG(INFO) << "Delay work for: " << x << "seconds for TFid: " << messagei.sTF << "and my ID is: " << Id
+                  << "and this is schedule nr: " << messagei.schedNum;
+        std::thread t3(MyDelayedFun, x, &freeSlots, &processingTime1);
+        t3.detach();
+      } else {
+        LOG(INFO) << "INFORMATION LOST DUE TO OVERCAPACITY AND MY ID IS: " << Id
+                  << "AND THIS IS SCHEDULE NR.: " << messagei.schedNum;
+        numberOfLostTfs1 << messagei.sTF << endl;
       }
     }
-
-
-
-
-
-
-void epn::send(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start,const uint64_t* max){
-  //change the sending
-        uint64_t now=getHistKey();
-        while((now-(*start))< *max){
-            auto &mySendingChan = GetChannel("epnsched");
-            EPNtoScheduler myMsg;
-            myMsg.Id = *id;
-            myMsg.freeSlots = *memory;
-            myMsg.numEPNs = *numepns;
-            FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(EPNtoScheduler));
-            std::memcpy(message->GetData(), &myMsg, sizeof(EPNtoScheduler));
-            mySendingChan.Send(message);
-
-           // LOG(INFO)<<"sent ID: "<<myMsg.Id<<" and amount of free slots              "<<myMsg.freeSlots<< " general amount of EPNs: "  <<myMsg.numEPNs << endl;
-            std::this_thread::sleep_for(std::chrono::milliseconds(long  (25)));
-            now=getHistKey();
-            }
-
+  }
 }
 
-thread epn::senderThread(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start,const uint64_t* max) {
-          return std::thread([=] {
-          this->send(memory,numepns,id,start, max);
-          });
+void epn::send(int *memory, uint64_t *numepns, uint64_t *id, uint64_t *start, const uint64_t *max) {
+  // change the sending
+  uint64_t now = getHistKey();
+  while ((now - (*start)) < *max) {
+    auto &mySendingChan = GetChannel("epnsched");
+    EPNtoScheduler myMsg;
+    myMsg.Id = *id;
+    myMsg.freeSlots = *memory;
+    myMsg.numEPNs = *numepns;
+    FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(EPNtoScheduler));
+    std::memcpy(message->GetData(), &myMsg, sizeof(EPNtoScheduler));
+    mySendingChan.Send(message);
 
-          // return std::thread(&epn::send, this, memory,numepns,id);
-      }
-
-void epn:: MyDelayedFun(float delayWork,int* memory, std::stringstream* procTime){
-     //(*memory)--;
-     //LOG(INFO)<<"amount of memory slots after decrementing: "<<*memory<<endl;
-     (*procTime) << delayWork << endl;
-     std::this_thread::sleep_for(std::chrono::milliseconds(long  (delayWork*1000)));
-     //cout<<"Delayed thread executioning the work now! \n";
-     (*memory)++;
+    // LOG(INFO)<<"sent ID: "<<myMsg.Id<<" and amount of free slots
+    // "<<myMsg.freeSlots<< " general amount of EPNs: "  <<myMsg.numEPNs <<
+    // endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(long(25)));
+    now = getHistKey();
+  }
 }
 
-float epn:: getDelay(){
-     static std::random_device generator;
-     std::normal_distribution<float> distribution(procTime, procDev);
-     float delay = distribution(generator);
-     return delay;
+thread epn::senderThread(int *memory, uint64_t *numepns, uint64_t *id, uint64_t *start, const uint64_t *max) {
+  return std::thread([=] { this->send(memory, numepns, id, start, max); });
+
+  // return std::thread(&epn::send, this, memory,numepns,id);
 }
 
-
-
-
-
-
-
-
-epn::~epn()
-{
+void epn::MyDelayedFun(float delayWork, int *memory, std::stringstream *procTime) {
+  //(*memory)--;
+  // LOG(INFO)<<"amount of memory slots after decrementing: "<<*memory<<endl;
+  (*procTime) << delayWork << endl;
+  std::this_thread::sleep_for(std::chrono::milliseconds(long(delayWork * 1000)));
+  // cout<<"Delayed thread executioning the work now! \n";
+  (*memory)++;
 }
 
+float epn::getDelay() {
+  static std::random_device generator;
+  std::normal_distribution<float> distribution(procTime, procDev);
+  float delay = distribution(generator);
+  return delay;
+}
+
+epn::~epn() {}
 }

--- a/examples/SCHEDULER-FLP-EPN/epn.h
+++ b/examples/SCHEDULER-FLP-EPN/epn.h
@@ -8,79 +8,58 @@
 #ifndef FAIRMQEXAMPLESCHEDULERFLPEPNEPN_H
 #define FAIRMQEXAMPLESCHEDULERFLPEPNEPN_H
 
-#include "FairMQDevice.h"
-#include "Message.h"
 #include <time.h>
 #include <iostream>
-#include <string>
 #include <random>
-#include <thread>
 #include <sstream>
+#include <string>
+#include <thread>
+#include "FairMQDevice.h"
+#include "Message.h"
 
+namespace example_SCHEDULER_FLP_EPN {
 
+class epn : public FairMQDevice {
+ public:
+  epn();
+  virtual ~epn();
+  void send(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start, const uint64_t* max);
 
+ protected:
+  uint64_t Id;
+  int freeSlots;
+  uint64_t maxSlots;
+  uint64_t numEPNS;
+  uint64_t numFLPS;
+  std::map<unsigned long, int> rcvdSTFs;
+  std::map<unsigned long, int>::iterator it;
+  int sTF;
 
-namespace example_SCHEDULER_FLP_EPN
-{
+  const float procTime;
+  const float procDev;
 
-class epn : public FairMQDevice
-{
-  public:
-    epn();
-    virtual ~epn();
-    void send(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start,const uint64_t* max);
+  uint64_t startTime;
+  uint64_t timeBetweenTf;
+  uint64_t programTime;  // the duration of the program.
+  const unsigned intMs;
 
+  std::stringstream receptionOfTf1;
+  std::stringstream processingTime1;
+  std::stringstream numberOfLostTfs1;
 
-  protected:
-    uint64_t Id;
-    int freeSlots;
-    uint64_t maxSlots;
-    uint64_t numEPNS;
-    uint64_t numFLPS;
-    std::map<unsigned long,int> rcvdSTFs;
-    std::map<unsigned long,int>::iterator it;
-    int sTF;
+  virtual void InitTask();
+  virtual bool ConditionalRun();
 
-    const float procTime;
-    const float procDev;
+  std::string getChannel(char number);
+  void receive();
 
-    uint64_t startTime;
-    uint64_t timeBetweenTf;
-    uint64_t programTime; //the duration of the program.
-    const unsigned intMs;
+  std::thread senderThread(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start, const uint64_t* max);
 
-    std::stringstream receptionOfTf1;
-    std::stringstream processingTime1;
-    std::stringstream numberOfLostTfs1;
+  static void MyDelayedFun(float delayWork, int* memory, std::stringstream* procTime);
+  float getDelay();
 
-
-
-
-
-    virtual void InitTask();
-    virtual bool ConditionalRun();
-
-    std::string getChannel(char number);
-    void receive();
-
-
-
-    std::thread senderThread(int* memory, uint64_t* numepns, uint64_t* id, uint64_t* start,const uint64_t* max);
-
-
-    static void MyDelayedFun(float delayWork, int* memory, std::stringstream* procTime);
-    float getDelay();
-
-    uint64_t getHistKey();
-
-
-
-
-
-
-
+  uint64_t getHistKey();
 };
-
 }
 
 #endif /* FAIRMQEXAMPLESCHEDULERFLPEPNEPN_H */

--- a/examples/SCHEDULER-FLP-EPN/flp.cxx
+++ b/examples/SCHEDULER-FLP-EPN/flp.cxx
@@ -3,162 +3,147 @@
  *
  */
 
-#include <memory> // unique_ptr
-#include <thread> // this_thread::sleep_for
 #include <chrono>
+#include <memory>  // unique_ptr
+#include <thread>  // this_thread::sleep_for
 
-
-#include "flp.h"
-#include "FairMQPoller.h"
-#include "Message.h"
 #include <fstream>
 #include <sstream>
 #include <string>
+#include "FairMQPoller.h"
+#include "Message.h"
+#include "flp.h"
 
 using namespace std;
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
 flp::flp()
-    : arrayofEpns()
-    , msBetweenSubtimeframes(25)
-    , amountEPNs(0)
-    , numEPNS(0)
-    , socket(0)
-    , myId(0)
-    , sTF(0)
-    , schedNum(0)
-    , startTime(0)
-    , programTime(0)
-    , amountOfLostTfs1()
-{
+    : arrayofEpns(),
+      msBetweenSubtimeframes(25),
+      amountEPNs(0),
+      numEPNS(0),
+      socket(0),
+      myId(0),
+      sTF(0),
+      schedNum(0),
+      startTime(0),
+      programTime(0),
+      amountOfLostTfs1() {}
+
+void flp::InitTask() {
+  amountEPNs = fConfig->GetValue<int>("amountEPNs");
+  numEPNS = fConfig->GetValue<uint64_t>("numEPNS");
+  socket = fConfig->GetValue<int>("socket");
+  myId = fConfig->GetValue<int>("myId");
+  programTime = fConfig->GetValue<uint64_t>("programTime");
+  arrayofEpns = new int[amountEPNs];
+  startTime = getHistKey();
 }
 
-void flp::InitTask()
-{
-    amountEPNs = fConfig->GetValue<int>("amountEPNs");
-    numEPNS= fConfig->GetValue<uint64_t>("numEPNS");
-    socket = fConfig->GetValue<int>("socket");
-    myId = fConfig->GetValue<int>("myId");
-    programTime = fConfig->GetValue<uint64_t>("programTime");
-    arrayofEpns = new int[amountEPNs];
-    startTime=getHistKey();
+static uint64_t getCurrentMs() {
+  // get the current time
+  const auto time = std::chrono::high_resolution_clock::now();
+  // get the time from THEN to now
+  auto duration = time.time_since_epoch();
+  const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+
+  return millis;
 }
 
-static
-uint64_t getCurrentMs(){
-    //get the current time
-    const auto time = std::chrono::high_resolution_clock::now();
-    //get the time from THEN to now
-    auto duration = time.time_since_epoch();
-    const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+void flp::Run() {
+  while (CheckCurrentState(RUNNING))  //
+  {
+    auto &myRecvChan = GetChannel("schedflp");
+    // I expect this kind of message
+    std::vector<uint64_t> msgIReceive(amountEPNs, 0);
 
-    return millis;
-}
-	
-void flp::Run()
-{
-    while (CheckCurrentState(RUNNING)) //
-    {
-            auto &myRecvChan = GetChannel("schedflp");
-            //I expect this kind of message
-            std::vector<uint64_t> msgIReceive (amountEPNs, 0);
+    // receive a message
+    FairMQMessagePtr aMessage = myRecvChan.NewMessage();
+    myRecvChan.Receive(aMessage);
+    // get the pointer of the message.
 
-            //receive a message
-            FairMQMessagePtr aMessage = myRecvChan.NewMessage();
-            myRecvChan.Receive(aMessage);
-            //get the pointer of the message.
+    std::memcpy(msgIReceive.data(), aMessage->GetData(), ((sizeof(uint64_t)) * amountEPNs));
+    if (aMessage->GetSize() == ((sizeof(uint64_t)) * amountEPNs)) {
+      schedNum++;
+      int i = 0;
+      for (vector<uint64_t>::const_iterator iter = msgIReceive.begin(); iter != msgIReceive.end(); ++iter) {
+        arrayofEpns[i] = *iter;
+        i++;
+      }
 
-            std::memcpy(msgIReceive.data(), aMessage->GetData(), ((sizeof(uint64_t))*amountEPNs));
-            if(aMessage->GetSize() ==((sizeof(uint64_t))*amountEPNs)){
-	      schedNum++;
-              int i=0;
-              for(vector<uint64_t>::const_iterator iter = msgIReceive.begin(); iter != msgIReceive.end(); ++iter){
-              arrayofEpns[i]=*iter;
-              i++;
+      if ((arrayofEpns[0] == 3) && (arrayofEpns[1] == 3)) {
+        for (int i = 0; i < numEPNS; i++) {
+          auto &mySendingChan = GetChannel("data", i);
+          FLPtoEPN MsgFlpEpn;
+          MsgFlpEpn.IdOfFlp = myId;
+          MsgFlpEpn.sTF = 1;
+          MsgFlpEpn.schedNum = -1;
+          FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(FLPtoEPN));
+          std::memcpy(message->GetData(), &MsgFlpEpn, sizeof(FLPtoEPN));
 
+          mySendingChan.Send(message);
+        }
 
-               }
+        ofstream amountOfLostTfs;
+        amountOfLostTfs.open("amountOfLostTfs.txt." + to_string(myId), std::ios_base::app);
+        amountOfLostTfs << amountOfLostTfs1.rdbuf();
+        LOG(INFO) << "TERMINATING PROGRAM NOW!";
+        return;
+      }
+      LOG(INFO) << "time now: " << getHistKey();
+      const auto startSendTime = getCurrentMs();
+      for (int i = 0; i < amountEPNs; i++) {
+        sTF++;
+        int c = arrayofEpns[i];
+        if (c >= 0) {
+          auto &mySendingChan = GetChannel("data", (c - 1));
+          // the message I want to send
+          FLPtoEPN MsgFlpEpn;
+          MsgFlpEpn.IdOfFlp = myId;
+          MsgFlpEpn.sTF = sTF;
+          MsgFlpEpn.schedNum = schedNum;
 
-		if((arrayofEpns[0]==3)&&(arrayofEpns[1]==3)){
-		for(int  i=0; i<numEPNS; i++){
-		    auto &mySendingChan = GetChannel("data", i);
-		    FLPtoEPN MsgFlpEpn;
-		    MsgFlpEpn.IdOfFlp=myId;
-		    MsgFlpEpn.sTF=1;
-		    MsgFlpEpn.schedNum=-1;
-		    FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(FLPtoEPN));
-                    std::memcpy(message->GetData(), &MsgFlpEpn, sizeof(FLPtoEPN));
+          FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(FLPtoEPN));
+          std::memcpy(message->GetData(), &MsgFlpEpn, sizeof(FLPtoEPN));
 
-                     mySendingChan.Send(message);
-		     }
-	        
-		ofstream amountOfLostTfs;
-                amountOfLostTfs.open("amountOfLostTfs.txt."+to_string(myId), std::ios_base::app);
-                amountOfLostTfs<<amountOfLostTfs1.rdbuf();
-                LOG(INFO)<<"TERMINATING PROGRAM NOW!";
-		return;
+          mySendingChan.Send(message);
+
+          LOG(info) << "Sent to Epn \"" << c << " and subtimeframe: " << MsgFlpEpn.sTF
+                    << " and my Id is: " << MsgFlpEpn.IdOfFlp << "\"";
+          if ((getCurrentMs() - startSendTime) / msBetweenSubtimeframes > i) {
+            continue;  // send more
+          } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(msBetweenSubtimeframes - 1));  // wait 25 - 1 ms.
           }
-	LOG(INFO)<< "time now: " << getHistKey();
-	const auto startSendTime = getCurrentMs();     
-        for(int i=0; i<amountEPNs; i++){
-            sTF++;
-            int c = arrayofEpns[i];
-	    if(c>=0){
-            auto &mySendingChan = GetChannel("data", (c-1));
-            //the message I want to send
-            FLPtoEPN MsgFlpEpn;
-            MsgFlpEpn.IdOfFlp = myId;
-            MsgFlpEpn.sTF = sTF;
-	    MsgFlpEpn.schedNum=schedNum;
+        }
 
-            FairMQMessagePtr message = mySendingChan.NewMessage(sizeof(FLPtoEPN));
-            std::memcpy(message->GetData(), &MsgFlpEpn, sizeof(FLPtoEPN));
-
-            mySendingChan.Send(message);
-
-            LOG(info) << "Sent to Epn \"" << c << " and subtimeframe: "<<MsgFlpEpn.sTF<< " and my Id is: "<< MsgFlpEpn.IdOfFlp<< "\"";
-	    if ((getCurrentMs() - startSendTime) / msBetweenSubtimeframes > i) {
-		    continue; // send more
-	    } else {
-            	std::this_thread::sleep_for(std::chrono::milliseconds(msBetweenSubtimeframes - 1)); //wait 25 - 1 ms.
-	    }
-            }
-		
-	   else{
-            //LOG(INFO)<< "Unfortunately there is no Epn guaranteeing the memory capacity";
-	    amountOfLostTfs1<<sTF<<endl;
-           }
-	}
-
-
+        else {
+          // LOG(INFO)<< "Unfortunately there is no Epn guaranteeing the memory
+          // capacity";
+          amountOfLostTfs1 << sTF << endl;
+        }
       }
     }
+  }
 }
 
-uint64_t flp::getHistKey(){
-    //get the current time
-    const auto time = std::chrono::high_resolution_clock::now();
-    //get the time from THEN to now
-    auto duration = time.time_since_epoch();
-    const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+uint64_t flp::getHistKey() {
+  // get the current time
+  const auto time = std::chrono::high_resolution_clock::now();
+  // get the time from THEN to now
+  auto duration = time.time_since_epoch();
+  const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
 
-    //std::cout << "Milliseconds : " << millis << std::endl;
-    //determine the interval (key for the hist map)
-    const std::uint64_t intKey = millis / 1000 * 1000;
-    //cout<< "histKey : " << intKey << endl;
+  // std::cout << "Milliseconds : " << millis << std::endl;
+  // determine the interval (key for the hist map)
+  const std::uint64_t intKey = millis / 1000 * 1000;
+  // cout<< "histKey : " << intKey << endl;
 
-    return intKey;
-
+  return intKey;
 }
 
-
-flp::~flp()
-{
-    if(arrayofEpns)
-        delete[] arrayofEpns;
-
+flp::~flp() {
+  if (arrayofEpns) delete[] arrayofEpns;
 }
 }
-

--- a/examples/SCHEDULER-FLP-EPN/flp.h
+++ b/examples/SCHEDULER-FLP-EPN/flp.h
@@ -7,43 +7,34 @@
 #ifndef FAIRMQEXAMPLESCHEDULERFLPEPNFLP_H
 #define FAIRMQEXAMPLESCHEDULERFLPEPNFLP_H
 
-
-
-#include "FairMQDevice.h"
 #include <sstream>
+#include "FairMQDevice.h"
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
-class flp : public FairMQDevice
-{
-  public:
-    flp();
-    virtual ~flp();
+class flp : public FairMQDevice {
+ public:
+  flp();
+  virtual ~flp();
 
-  protected:
-    int* arrayofEpns; //just declare a pointer
+ protected:
+  int* arrayofEpns;  // just declare a pointer
 
+  const unsigned msBetweenSubtimeframes;
+  int amountEPNs;  // amount of epns in scheduler
+  uint64_t numEPNS;
+  int socket;
+  int myId;
+  int sTF;
+  int schedNum;
+  uint64_t startTime;
+  uint64_t programTime;
+  std::stringstream amountOfLostTfs1;
 
-
-    const unsigned msBetweenSubtimeframes;
-    int amountEPNs; //amount of epns in scheduler
-    uint64_t numEPNS;
-    int socket;
-    int myId;
-    int sTF;
-    int schedNum;
-    uint64_t startTime;
-    uint64_t programTime;
-    std::stringstream amountOfLostTfs1;
-
-
-
-    virtual void Run();
-    virtual void InitTask();
-    uint64_t getHistKey();
+  virtual void Run();
+  virtual void InitTask();
+  uint64_t getHistKey();
 };
-
 }
 
 #endif /* FAIRMQEXAMPLESCHEDULERFLPEPNFLP_H */

--- a/examples/SCHEDULER-FLP-EPN/runEpn.cxx
+++ b/examples/SCHEDULER-FLP-EPN/runEpn.cxx
@@ -1,19 +1,14 @@
-#include "runFairMQDevice.h"
 #include "epn.h"
+#include "runFairMQDevice.h"
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& options)
-{
-    options.add_options()
-        ("myId", bpo::value<uint64_t>()->default_value(377), "ID")
-        ("maxSlots", bpo::value<uint64_t>()->default_value(3), "amount of free Slots")
-        ("numEPNS", bpo::value<uint64_t>()->default_value(43), "number of EPNs")
-        ("numFLPS", bpo::value<uint64_t>()->default_value(1), "amount of Flps")
-        ("programTime", bpo::value<uint64_t>()->default_value(1), "time of the program");
+void addCustomOptions(bpo::options_description &options) {
+  options.add_options()("myId", bpo::value<uint64_t>()->default_value(377), "ID")(
+      "maxSlots", bpo::value<uint64_t>()->default_value(3), "amount of free Slots")(
+      "numEPNS", bpo::value<uint64_t>()->default_value(43), "number of EPNs")(
+      "numFLPS", bpo::value<uint64_t>()->default_value(1), "amount of Flps")(
+      "programTime", bpo::value<uint64_t>()->default_value(1), "time of the program");
 }
 
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
-{
-    return new example_SCHEDULER_FLP_EPN::epn();
-}
+FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/) { return new example_SCHEDULER_FLP_EPN::epn(); }

--- a/examples/SCHEDULER-FLP-EPN/runFlp.cxx
+++ b/examples/SCHEDULER-FLP-EPN/runFlp.cxx
@@ -1,20 +1,14 @@
-#include "runFairMQDevice.h"
 #include "flp.h"
+#include "runFairMQDevice.h"
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& options)
-{
-    options.add_options()
-      ("amountEPNs", bpo::value<int>()->default_value(0), "number of the EPNs in the schedule")
-      ("numEPNS", bpo::value<uint64_t>()->default_value(0), "total number of EPNs")
-      ("socket", bpo::value<int>()->default_value(0), "socket number")
-      ("myId", bpo::value<int>()->default_value(0), "IdofFlp")
-      ("programTime", bpo::value<uint64_t>()->default_value(1), "time of the program");
-
+void addCustomOptions(bpo::options_description &options) {
+  options.add_options()("amountEPNs", bpo::value<int>()->default_value(0), "number of the EPNs in the schedule")(
+      "numEPNS", bpo::value<uint64_t>()->default_value(0), "total number of EPNs")(
+      "socket", bpo::value<int>()->default_value(0), "socket number")(
+      "myId", bpo::value<int>()->default_value(0), "IdofFlp")("programTime", bpo::value<uint64_t>()->default_value(1),
+                                                              "time of the program");
 }
 
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
-{
-    return new example_SCHEDULER_FLP_EPN::flp();
-}
+FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/) { return new example_SCHEDULER_FLP_EPN::flp(); }

--- a/examples/SCHEDULER-FLP-EPN/runScheduler.cxx
+++ b/examples/SCHEDULER-FLP-EPN/runScheduler.cxx
@@ -5,18 +5,11 @@
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& options)
-{
-    options.add_options()
-    ("numEPNS", bpo::value<uint64_t>()->default_value(43), "number of EPNs")
-    ("numFLPS", bpo::value<uint64_t>()->default_value(0), "number of Flps")
-    ("amountEPNs", bpo::value<uint64_t>()->default_value(0), "the number of EPNs in the schedule")
-    ("programTime", bpo::value<uint64_t>()->default_value(1), "time of the program");
-
+void addCustomOptions(bpo::options_description &options) {
+  options.add_options()("numEPNS", bpo::value<uint64_t>()->default_value(43), "number of EPNs")(
+      "numFLPS", bpo::value<uint64_t>()->default_value(0), "number of Flps")(
+      "amountEPNs", bpo::value<uint64_t>()->default_value(0), "the number of EPNs in the schedule")(
+      "programTime", bpo::value<uint64_t>()->default_value(1), "time of the program");
 }
 
-
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
-{
-    return new example_SCHEDULER_FLP_EPN::scheduler();
-}
+FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/) { return new example_SCHEDULER_FLP_EPN::scheduler(); }

--- a/examples/SCHEDULER-FLP-EPN/scheduler.cxx
+++ b/examples/SCHEDULER-FLP-EPN/scheduler.cxx
@@ -3,466 +3,428 @@
  *
  */
 
-#include <thread> // this_thread::sleep_for
-#include <chrono>
-#include <memory>
 #include "scheduler.h"
-#include "Message.h"
-#include <string>
-#include <vector>
-#include <map>
-#include <iostream>
+#include <chrono>
 #include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
+#include <thread>  // this_thread::sleep_for
+#include <vector>
+#include "Message.h"
 
 using namespace std;
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
 scheduler::scheduler()
-          :history()
-          ,numEPNS(0)
-          ,numFLPS(0)
-          ,intMs(1000) //one second
-          ,programTime(0)//alive time of the program
-          ,historyMaxMs(59*1*intMs)//one minute
-          ,msBetweenSubtimeframes(0.625)
-          ,amountEPNs(0)
-          ,intervalFLPs(1)//interval of sending out schedule
-          ,vectorForFlps(0)
-          ,availableEpns1()
-          ,EpnsInSchedule1()
-          ,heatdata1()
-          ,tooOld(0)
-          ,keyForToFile(0)
-          ,keyForGeneratingArray(0)
-          ,keyForExiting(0)
-          ,scheduleNumber(0)
-          ,m(1)
+    : history(),
+      numEPNS(0),
+      numFLPS(0),
+      intMs(1000)  // one second
+      ,
+      programTime(0)  // alive time of the program
+      ,
+      historyMaxMs(59 * 1 * intMs)  // one minute
+      ,
+      msBetweenSubtimeframes(0.625),
+      amountEPNs(0),
+      intervalFLPs(1)  // interval of sending out schedule
+      ,
+      vectorForFlps(0),
+      availableEpns1(),
+      EpnsInSchedule1(),
+      heatdata1(),
+      tooOld(0),
+      keyForToFile(0),
+      keyForGeneratingArray(0),
+      keyForExiting(0),
+      scheduleNumber(0),
+      m(1)
 
-{
+{}
+
+void scheduler::InitTask() {
+  numEPNS = fConfig->GetValue<uint64_t>("numEPNS");
+  numFLPS = fConfig->GetValue<uint64_t>("numFLPS");
+  amountEPNs = fConfig->GetValue<uint64_t>("amountEPNs");
+  programTime = fConfig->GetValue<uint64_t>("programTime");
+  initialize(numEPNS);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+  keyForToFile = getHistKey();
+  keyForGeneratingArray = getHistKey();
+  keyForExiting = getHistKey();
 }
 
-void scheduler::InitTask(){
-    numEPNS = fConfig->GetValue<uint64_t>("numEPNS");
-    numFLPS=fConfig->GetValue<uint64_t>("numFLPS");
-    amountEPNs=fConfig->GetValue<uint64_t>("amountEPNs");
-    programTime=fConfig->GetValue<uint64_t>("programTime");
-    initialize(numEPNS);
-    std::this_thread::sleep_for(std::chrono::milliseconds (10000));
-    keyForToFile=getHistKey();
-    keyForGeneratingArray=getHistKey();
-    keyForExiting=getHistKey();
-  
+bool scheduler::ConditionalRun() {
+  if ((getHistKey() - keyForExiting) > (programTime * 60 * 1000)) {
+    // SEND MESSAGE TO FLPS SAYING IT's ALL 3
+    vector<uint64_t> vect;
+    for (int i = 0; i < amountEPNs; i++) {
+      vect.push_back(3);
+    }
 
+    for (uint64_t i = 0; i < numFLPS; i++) {
+      auto &mySendingChan = GetChannel("schedflp", i);
+      FairMQMessagePtr message = mySendingChan.NewMessage((sizeof(uint64_t)) * vect.size());
+      std::memcpy(message->GetData(), vect.data(), message->GetSize());
+      mySendingChan.Send(message);
+    }
 
-}
+    LOG(INFO) << "about to terminate the program!";
+    ofstream ofHeatdata, ofEpnsInSchedule, ofAvailableEpns;
+    ofHeatdata.open("heatdata.txt", std::ios_base::app);
+    ofEpnsInSchedule.open("EpnsInSchedule.txt", std::ios_base::app);
+    ofAvailableEpns.open("availableEpns.txt", std::ios_base::app);
+    ofHeatdata << heatdata1.rdbuf();
+    ofEpnsInSchedule << EpnsInSchedule1.rdbuf();
+    ofAvailableEpns << availableEpns1.rdbuf();
 
+    LOG(INFO) << "TERMINATING PROGRAM NOW!";
+    return false;
+  }
 
-bool scheduler::ConditionalRun()
-{
-   if((getHistKey()-keyForExiting)>(programTime*60*1000)){
-	//SEND MESSAGE TO FLPS SAYING IT's ALL 3
-	vector<uint64_t> vect;
-	for(int i=0; i<amountEPNs;i++) {
-		vect.push_back(3);
-	}
-	
+  else {
+    FairMQPollerPtr poller(NewPoller("epnsched"));
+    poller->Poll(100);
 
-	for(uint64_t i=0; i<numFLPS; i++) {
-		auto &mySendingChan = GetChannel("schedflp", i);
-		FairMQMessagePtr message = mySendingChan.NewMessage((sizeof(uint64_t))*vect.size());
-		std::memcpy(message->GetData(), vect.data(), message->GetSize());
-		mySendingChan.Send(message);
-       }
+    for (int i = 0; i < numEPNS; i++) {
+      if (poller->CheckInput("epnsched", i)) {
+        auto &myRecvChan = GetChannel("epnsched", i);
+        // try to receive more updates
+        // I expect this kind of messages
+        EPNtoScheduler msgFromSender;
+        if (true) {
+          // receive a message
+          FairMQMessagePtr aMessage = myRecvChan.NewMessage();
+          if (myRecvChan.Receive(aMessage) == sizeof(EPNtoScheduler)) {
+            if (aMessage->GetSize() == sizeof(EPNtoScheduler)) {
+              // get the data of the FairMQ message
+              std::memcpy(&msgFromSender, aMessage->GetData(), sizeof(EPNtoScheduler));
+              // LOG(INFO)<<"received ID: "<<msgFromSender.Id<<" and amount of
+              // free slots "<<msgFromSender.freeSlots<<" and amount of EPNs is:
+              // "<< msgFromSender.numEPNs << endl;
+              update(msgFromSender.Id, msgFromSender.freeSlots);
+            }
+          } else {
+            break;
+          }
+        }
+      }
+    }
 
-      LOG(INFO)<<"about to terminate the program!";
-      ofstream ofHeatdata, ofEpnsInSchedule, ofAvailableEpns;
-      ofHeatdata.open("heatdata.txt", std::ios_base::app);
-      ofEpnsInSchedule.open("EpnsInSchedule.txt",std::ios_base::app);
-      ofAvailableEpns.open("availableEpns.txt", std::ios_base::app);
-      ofHeatdata<<heatdata1.rdbuf();
-      ofEpnsInSchedule<<EpnsInSchedule1.rdbuf();
-      ofAvailableEpns<<availableEpns1.rdbuf();
+    if (getHistKey() >= (keyForGeneratingArray + uint64_t(intervalFLPs * 1000.0))) {
+      LOG(INFO) << "next time " << (keyForGeneratingArray + uint64_t(intervalFLPs * 1000.0));
 
-      LOG(INFO)<<"TERMINATING PROGRAM NOW!";
-      return false;
-	}
-	
-    else{
+      LOG(INFO) << "Creating the schedule " << scheduleNumber << " at time " << getHistKey() << " lastKey "
+                << keyForGeneratingArray;
+      LOG(INFO) << "intervalFLPs " << intervalFLPs;
 
-    
-  	 FairMQPollerPtr poller(NewPoller("epnsched"));
-  	 poller->Poll(100);
-
-   	 for(int i= 0; i < numEPNS; i++){
-     		 if (poller->CheckInput("epnsched", i)) {
-			 auto &myRecvChan = GetChannel("epnsched",i);
-			 // try to receive more updates
-			 // I expect this kind of messages
-			 EPNtoScheduler msgFromSender;
-			 if(true) {
-				 // receive a message
-				 FairMQMessagePtr aMessage = myRecvChan.NewMessage();
-				 if (myRecvChan.Receive(aMessage) == sizeof(EPNtoScheduler)) {
-					if(aMessage->GetSize() == sizeof(EPNtoScheduler)){ 
-						 // get the data of the FairMQ message
-					 	std::memcpy(&msgFromSender, aMessage->GetData(), sizeof(EPNtoScheduler));
-						//LOG(INFO)<<"received ID: "<<msgFromSender.Id<<" and amount of free slots "<<msgFromSender.freeSlots<<" and amount of EPNs is: "<< msgFromSender.numEPNs << endl;
-						update(msgFromSender.Id, msgFromSender.freeSlots);
-					}
-				}
-				else{
-					break;
-			       	}
-			}
-		 }
-   	 }
-
-   	 if(getHistKey() >= (keyForGeneratingArray + uint64_t( intervalFLPs*1000.0))){
-    
-		LOG(INFO) << "next time " << (keyForGeneratingArray + uint64_t(intervalFLPs*1000.0));
-
-		LOG(INFO) << "Creating the schedule " << scheduleNumber << " at time " << getHistKey() << " lastKey " << keyForGeneratingArray;
-       		LOG(INFO) << "intervalFLPs " << intervalFLPs;
-
-	 	 //vectorForFlps=simpleRRSched(m);
-        	 //m=(m+amountEPNs)%numEPNS;
-		int f = availableEpns(generateArray1(), numEPNS);
-		LOG(INFO)<<"Epns having at least one free memory slot: "<< f;
-        	availableEpns1<<f<<endl;
-		int inSchedule= EpnsInSchedule(f, amountEPNs);
-		LOG(INFO)<<"Epns in Schedule: "<< inSchedule;
-         	EpnsInSchedule1<<inSchedule<<endl;
-		vectorForFlps = generateSchedule();
-         	//printVecFLP(vectorForFlps);
-         	keyForGeneratingArray = getHistKey();
-         	scheduleNumber++;
-         	std::thread t1= senderThread(&vectorForFlps, &numFLPS, &amountEPNs, &scheduleNumber);
-         	t1.detach();
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    	}
-     }
+      // vectorForFlps=simpleRRSched(m);
+      // m=(m+amountEPNs)%numEPNS;
+      int f = availableEpns(generateArray1(), numEPNS);
+      LOG(INFO) << "Epns having at least one free memory slot: " << f;
+      availableEpns1 << f << endl;
+      int inSchedule = EpnsInSchedule(f, amountEPNs);
+      LOG(INFO) << "Epns in Schedule: " << inSchedule;
+      EpnsInSchedule1 << inSchedule << endl;
+      vectorForFlps = generateSchedule();
+      // printVecFLP(vectorForFlps);
+      keyForGeneratingArray = getHistKey();
+      scheduleNumber++;
+      std::thread t1 = senderThread(&vectorForFlps, &numFLPS, &amountEPNs, &scheduleNumber);
+      t1.detach();
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
   return true;
 }
 
-
-
-
-thread scheduler::senderThread(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum){
-    return std::thread([=]{
-    this->sender(vec, num, numE, schedNum);
-  });
+thread scheduler::senderThread(std::vector<uint64_t> *vec, uint64_t *num, uint64_t *numE, uint64_t *schedNum) {
+  return std::thread([=] { this->sender(vec, num, numE, schedNum); });
 }
 
+uint64_t scheduler::getHistKey() {
+  // get the current time
+  const auto time = std::chrono::high_resolution_clock::now();
+  // get the time from THEN to now
+  auto duration = time.time_since_epoch();
+  const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  // std::cout << "Milliseconds : " << millis << std::endl;
+  // determine the interval (key for the hist map)
+  const std::uint64_t intKey = millis / 1000 * 1000;
+  //     const std::uint64_t intKey = millis /  25   * 25;
+  // cout<< "histKey : " << intKey << endl;
 
-
-uint64_t scheduler::getHistKey(){
-    //get the current time
-    const auto time = std::chrono::high_resolution_clock::now();
-    //get the time from THEN to now
-    auto duration = time.time_since_epoch();
-    const std::uint64_t millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-    //std::cout << "Milliseconds : " << millis << std::endl;
-    //determine the interval (key for the hist map)
-    const std::uint64_t intKey = millis / 1000  * 1000;
-//     const std::uint64_t intKey = millis /  25   * 25;
-    //cout<< "histKey : " << intKey << endl;
-
-    return intKey;
-
+  return intKey;
 }
 
-void scheduler::initialize(uint64_t numberofEPNs){
-    //history is empty
-    //get my key
-    const auto key = getHistKey();
+void scheduler::initialize(uint64_t numberofEPNs) {
+  // history is empty
+  // get my key
+  const auto key = getHistKey();
 
-    if (history.count(key) == 0) {
-        history.insert(pair<uint64_t, vector<EpnInfo>> (key, vector<EpnInfo> (numberofEPNs)));
-	for(uint64_t a=0; a < numEPNS; a++){
-		history[key].at(a).ts=key;
-		history[key].at(a).memVal=3;
-		}
+  if (history.count(key) == 0) {
+    history.insert(pair<uint64_t, vector<EpnInfo>>(key, vector<EpnInfo>(numberofEPNs)));
+    for (uint64_t a = 0; a < numEPNS; a++) {
+      history[key].at(a).ts = key;
+      history[key].at(a).memVal = 3;
     }
+  }
 }
 
 void scheduler::printHist() {
+  for (auto &keyVal : history) {
+    // const auto Key = keyVal.first;
+    const auto &Epns = keyVal.second;
 
-    for (auto &keyVal : history) {
-        //const auto Key = keyVal.first;
-        const auto &Epns = keyVal.second;
-
-        //std::cout << "TimeInterval: " << Key << endl;
-        for(auto &epnI : Epns) {
-            cout << epnI.ts << ":" << epnI.memVal << " ";
-        }
+    // std::cout << "TimeInterval: " << Key << endl;
+    for (auto &epnI : Epns) {
+      cout << epnI.ts << ":" << epnI.memVal << " ";
     }
-    cout << endl;
+  }
+  cout << endl;
 }
 
 void scheduler::update(uint64_t epnId, uint64_t myMem) {
-    // get the key (also current time)
-    const auto key = getHistKey();
+  // get the key (also current time)
+  const auto key = getHistKey();
 
-    //checking if the key already exists
-    if(history.count(key) != 0) {
-        history[key].at(epnId-1).ts = key;
-        history[key].at(epnId-1).memVal = myMem;
+  // checking if the key already exists
+  if (history.count(key) != 0) {
+    history[key].at(epnId - 1).ts = key;
+    history[key].at(epnId - 1).memVal = myMem;
+  }
+  // case that key does not exist.
+  else {  // get the previous key
+    auto prevKey = history.rbegin();
+    uint64_t prevKeyInt = prevKey->first;
+
+    // insert a new vector
+    history.insert(pair<uint64_t, vector<EpnInfo>>(key, vector<EpnInfo>(numEPNS)));
+
+    // copy the old values in the new vector
+    for (uint64_t a = 0; a < numEPNS; a++) {
+      // check if EPN did get lost.
+      if (history[prevKeyInt].at(a).ts < tooOld) {
+        history[key].at(a).ts = 0;
+        history[key].at(a).memVal = 0;
+      } else {
+        history[key].at(a).ts = history[prevKeyInt].at(a).ts;
+        history[key].at(a).memVal = history[prevKeyInt].at(a).memVal;
+      }
     }
-    //case that key does not exist.
-    else{//get the previous key
-        auto prevKey = history.rbegin();
-        uint64_t prevKeyInt = prevKey->first;
 
-            //insert a new vector
-            history.insert(pair<uint64_t, vector<EpnInfo>> (key, vector<EpnInfo> (numEPNS)));
+    // overwrite with the current values.
+    history[key].at(epnId - 1).ts = key;
+    history[key].at(epnId - 1).memVal = myMem;
 
-            //copy the old values in the new vector
-            for(uint64_t a = 0; a < numEPNS; a++ ) {
-                //check if EPN did get lost.
-                if(history[prevKeyInt].at(a).ts < tooOld){
-                    history[key].at(a).ts = 0;
-                    history[key].at(a).memVal=0;
-                    }
-                else{
-                history[key].at(a).ts=history[prevKeyInt].at(a).ts;
-                history[key].at(a).memVal=history[prevKeyInt].at(a).memVal;
-                }
-           }
-
-            //overwrite with the current values.
-            history[key].at(epnId-1).ts = key;
-            history[key].at(epnId-1).memVal = myMem;
-
-       // }
-    }
-    // check if the history should be trimmed
-    //get first key
-    auto firstKey = history.begin();
-    tooOld = (*firstKey).first;
-        while(key>=(tooOld+historyMaxMs)){
-            //delete the first key.
-            history.erase(firstKey);
-            auto newFirstKey = history.begin();
-           //update tooOld integer
-            tooOld =  newFirstKey->first;
-        }
-        //write history to file every minute.
-    if(key >= (keyForToFile + historyMaxMs)){
-        toFile();
-        keyForToFile = key;
-        }
-       
-
-
-
-
-
-
-
+    // }
+  }
+  // check if the history should be trimmed
+  // get first key
+  auto firstKey = history.begin();
+  tooOld = (*firstKey).first;
+  while (key >= (tooOld + historyMaxMs)) {
+    // delete the first key.
+    history.erase(firstKey);
+    auto newFirstKey = history.begin();
+    // update tooOld integer
+    tooOld = newFirstKey->first;
+  }
+  // write history to file every minute.
+  if (key >= (keyForToFile + historyMaxMs)) {
+    toFile();
+    keyForToFile = key;
+  }
 }
 
-void scheduler::toFile(){
-    for(auto a = history.begin(); a != history.end(); a ++ ){
-        for(uint64_t i = 0; i < (numEPNS-1); i++){
-            //LOG(INFO)<< "inside FILE LOOP and writing to history: "<< history[(*a).first].at(i).memVal;
-            heatdata1 << history[(*a).first].at(i).memVal << ", ";
-
-        }
-        //LOG(INFO)<< "outer For loop and writing the last value of the history to file which is"<<history[(*a).first].at(numEPNS-1).memVal;
-        heatdata1 << history[(*a).first].at(numEPNS-1).memVal << endl;
+void scheduler::toFile() {
+  for (auto a = history.begin(); a != history.end(); a++) {
+    for (uint64_t i = 0; i < (numEPNS - 1); i++) {
+      // LOG(INFO)<< "inside FILE LOOP and writing to history: "<<
+      // history[(*a).first].at(i).memVal;
+      heatdata1 << history[(*a).first].at(i).memVal << ", ";
     }
+    // LOG(INFO)<< "outer For loop and writing the last value of the history to
+    // file which is"<<history[(*a).first].at(numEPNS-1).memVal;
+    heatdata1 << history[(*a).first].at(numEPNS - 1).memVal << endl;
+  }
 }
 
-
-std::vector<uint64_t> scheduler::generateSchedule(){
-	//LOG(INFO)<< "inside generating schedule";
-    vector<int> temporaryStorage = generateArray1(); //pointer to array of amount of EPNs which we need to store the memory size of the valid EPNs
-	//LOG(INFO)<<"generated temporary Storage vector";
-    std::vector<uint64_t> desFLPsPointer;
-	//LOG(INFO)<<"vector desFLPsPointer generated";
-    //printfreeSlots(temporaryStorage, 1);
-    //using maxSearchFunction the size of "amountEPNs" times to get the Ids of the EPNs with the highest memory capacities
-    for(uint64_t i = 0; i < amountEPNs; i++){
-	//LOG(INFO)<<"Inside for loop for finding  the max value the "<<i<<". time";
-        int maxIndex = maxSearch(temporaryStorage);
-        desFLPsPointer.push_back(maxIndex); //index of the EPNs with most memory capacity
-    }
-
-    // now decrement resources of selected EPNs!
-    // so they are not use in the next schedule again
-    auto latestKey = history.rbegin();
-    for (unsigned i = 0; i < desFLPsPointer.size(); i++) {
-        if (desFLPsPointer[i] == -1){
-            continue;
-	}
-
-        // just to check
-	uint64_t realIndex= desFLPsPointer[i]-1;
-        if (latestKey->second.at(realIndex).memVal <= 0){
-            LOG(WARNING) << "ERROR: EPN selected for schedule but does not have memory slots!";
-	    LOG(WARNING) << "memory slots not decreased";
-	    }
-        else{
-            latestKey->second.at(realIndex).memVal -= 1;
-	    //LOG(INFO)<< "decreased memory slots in history";
-		}
-    }
-
-    return desFLPsPointer;
-}
-
-vector<int> scheduler::generateArray1()
-{
-    vector<int> temporaryStorage(numEPNS, -1 /* def value */);
-
-    auto latestKey = history.rbegin();
-    // checking whether the EPNs are valid
-    for (uint64_t i = 0; i < numEPNS; i++) {
-        if (latestKey->second.at(i).ts + 5000 >= latestKey->first) {
-            // writing the memory values of the valid EPns in array
-            temporaryStorage[i] = latestKey->second.at(i).memVal;
-        } else {               // setting the other values to -1
-            temporaryStorage[i] = -1;
-            latestKey->second.at(i).memVal = -1; // mark them as failed
-        }
-    }
-
-    return temporaryStorage;
-}
-
-int scheduler::maxSearch(vector<int> &arr){
-    int max = arr[0];
-    int index = 0;
-    for(uint64_t i=1;i < numEPNS; i++){
-        if(max < arr[i]){
-            max = arr[i];
-            index = i;
-        }
-    }
-
-    if(arr[index] == 0 || arr[index]==-1) {
-	arr[index]= -1;
-        return -1;
-    } else{
-        arr[index] = -1;
-        return index+1;
-    }
-}
-
-void scheduler::printVecFLP(std::vector<uint64_t> a){
-     for(int b=0; b != a.size(); b ++ ){
-    cout << "Printing the vector for the flps. number: "<< b+1<<" goes to: "<< a.at(b) <<endl;
-}
-}
-
-
-void scheduler::printfreeSlots(int arr[], int length){
-       for (int n=0; n<length; ++n)
-      cout << "free Slots: "<< arr[n] << ' ';
-    cout << '\n';
+std::vector<uint64_t> scheduler::generateSchedule() {
+  // LOG(INFO)<< "inside generating schedule";
+  vector<int> temporaryStorage = generateArray1();  // pointer to array of amount of EPNs which we need to
+                                                    // store the memory size of the valid EPNs
+  // LOG(INFO)<<"generated temporary Storage vector";
+  std::vector<uint64_t> desFLPsPointer;
+  // LOG(INFO)<<"vector desFLPsPointer generated";
+  // printfreeSlots(temporaryStorage, 1);
+  // using maxSearchFunction the size of "amountEPNs" times to get the Ids of
+  // the EPNs with the highest memory capacities
+  for (uint64_t i = 0; i < amountEPNs; i++) {
+    // LOG(INFO)<<"Inside for loop for finding  the max value the "<<i<<".
+    // time";
+    int maxIndex = maxSearch(temporaryStorage);
+    desFLPsPointer.push_back(maxIndex);  // index of the EPNs with most memory capacity
   }
 
-
-
-void scheduler::sender(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum){
-    const vector<uint64_t> lVec = *vec;
-    assert(lVec.size() == amountEPNs);
-    vec->clear();
-
-    for(vector<uint64_t>::const_iterator iter = lVec.begin(); iter!=lVec.end(); ++iter){
-
-        LOG(INFO)<<"Schedule number "<< *schedNum<<" sent Id of epn which is: "<< *iter;
-      }
-
-    for(uint64_t i=0; i<numFLPS; i++){
-      auto &mySendingChan = GetChannel("schedflp", i);
-
-      FairMQMessagePtr message = mySendingChan.NewMessage((sizeof(uint64_t))*lVec.size());
-
-
-      std::memcpy(message->GetData(), lVec.data(), message->GetSize());
-      mySendingChan.Send(message);
-
+  // now decrement resources of selected EPNs!
+  // so they are not use in the next schedule again
+  auto latestKey = history.rbegin();
+  for (unsigned i = 0; i < desFLPsPointer.size(); i++) {
+    if (desFLPsPointer[i] == -1) {
+      continue;
     }
 
+    // just to check
+    uint64_t realIndex = desFLPsPointer[i] - 1;
+    if (latestKey->second.at(realIndex).memVal <= 0) {
+      LOG(WARNING) << "ERROR: EPN selected for schedule but does not have memory slots!";
+      LOG(WARNING) << "memory slots not decreased";
+    } else {
+      latestKey->second.at(realIndex).memVal -= 1;
+      // LOG(INFO)<< "decreased memory slots in history";
+    }
+  }
+
+  return desFLPsPointer;
 }
 
-int scheduler::availableEpns(const vector<int> &arr,uint64_t siz) const {
-  int c=0;
-  for(uint64_t i=0;i<siz;i++){
-    if(arr[i]>0){
+vector<int> scheduler::generateArray1() {
+  vector<int> temporaryStorage(numEPNS, -1 /* def value */);
+
+  auto latestKey = history.rbegin();
+  // checking whether the EPNs are valid
+  for (uint64_t i = 0; i < numEPNS; i++) {
+    if (latestKey->second.at(i).ts + 5000 >= latestKey->first) {
+      // writing the memory values of the valid EPns in array
+      temporaryStorage[i] = latestKey->second.at(i).memVal;
+    } else {  // setting the other values to -1
+      temporaryStorage[i] = -1;
+      latestKey->second.at(i).memVal = -1;  // mark them as failed
+    }
+  }
+
+  return temporaryStorage;
+}
+
+int scheduler::maxSearch(vector<int> &arr) {
+  int max = arr[0];
+  int index = 0;
+  for (uint64_t i = 1; i < numEPNS; i++) {
+    if (max < arr[i]) {
+      max = arr[i];
+      index = i;
+    }
+  }
+
+  if (arr[index] == 0 || arr[index] == -1) {
+    arr[index] = -1;
+    return -1;
+  } else {
+    arr[index] = -1;
+    return index + 1;
+  }
+}
+
+void scheduler::printVecFLP(std::vector<uint64_t> a) {
+  for (int b = 0; b != a.size(); b++) {
+    cout << "Printing the vector for the flps. number: " << b + 1 << " goes to: " << a.at(b) << endl;
+  }
+}
+
+void scheduler::printfreeSlots(int arr[], int length) {
+  for (int n = 0; n < length; ++n) cout << "free Slots: " << arr[n] << ' ';
+  cout << '\n';
+}
+
+// make sure 2 send threads use the same sockets
+static std::mutex sched_chan_mutex;
+
+void scheduler::sender(std::vector<uint64_t> *vec, uint64_t *num, uint64_t *numE, uint64_t *schedNum) {
+  const vector<uint64_t> lVec = *vec;
+
+  // only 1 thread can use this channel at a time
+  std::lock_guard<std::mutex> guard(sched_chan_mutex);
+  LOG(INFO) << "Sender thread starting for schedule: " << *schedNum << " at: " << getHistKey();
+
+  assert(lVec.size() == amountEPNs);
+  vec->clear();
+
+  for (vector<uint64_t>::const_iterator iter = lVec.begin(); iter != lVec.end(); ++iter) {
+    LOG(INFO) << "Schedule number " << *schedNum << " sent Id of epn which is: " << *iter;
+  }
+
+  for (uint64_t i = 0; i < numFLPS; i++) {
+    auto &mySendingChan = GetChannel("schedflp", i);
+
+    FairMQMessagePtr message = mySendingChan.NewMessage((sizeof(uint64_t)) * lVec.size());
+
+    std::memcpy(message->GetData(), lVec.data(), message->GetSize());
+    mySendingChan.Send(message);
+  }
+
+  LOG(INFO) << "Sender thread finished distributing schedule: " << *schedNum;
+}
+
+int scheduler::availableEpns(const vector<int> &arr, uint64_t siz) const {
+  int c = 0;
+  for (uint64_t i = 0; i < siz; i++) {
+    if (arr[i] > 0) {
       c++;
     }
   }
   return c;
 }
 
-int scheduler::EpnsInSchedule(int avaiable, uint64_t siz){
-	if(avaiable<siz){
-		return avaiable;
-		}
-	else{
-		return siz;
-		}
+int scheduler::EpnsInSchedule(int avaiable, uint64_t siz) {
+  if (avaiable < siz) {
+    return avaiable;
+  } else {
+    return siz;
+  }
 }
 
-
-
-
-std::vector<uint64_t> scheduler::simpleRRSched(int mm){
-  LOG(INFO)<<"before creating vector";
+std::vector<uint64_t> scheduler::simpleRRSched(int mm) {
+  LOG(INFO) << "before creating vector";
   std::vector<uint64_t> roundr;
-  LOG(INFO)<<"just created vector";
+  LOG(INFO) << "just created vector";
   auto prevKey = history.rbegin();
-  LOG(INFO)<<"got the last key";
+  LOG(INFO) << "got the last key";
   uint64_t prevKeyInt = prevKey->first;
-  LOG(INFO)<<"made the last key to an integer";
-  for(int j=mm; j<(mm+amountEPNs);j++){
-	 LOG(INFO)<<"inside the for loop";
-	if(j<=numEPNS){
- 		 if(history[prevKeyInt].at(j-1).memVal==0){ //case that it's either zero or broken
-			LOG(INFO)<<"no memory capacity";
-			roundr.push_back(-1);
-			LOG(INFO)<<"inserted -1 in the vector";
-			}
-		 else{
-			LOG(INFO)<<"memory capacity";	
-   	       		roundr.push_back(j);
-			LOG(INFO)<<"pushed back: "<< j;
- 	       		}
-		}
-	else{
-		int k = j%numEPNS;
-		if(history[prevKeyInt].at(k-1).memVal==0){ //case that it's either zero or broken
-                       		 LOG(INFO)<<"no memory capacity";
-                       		 roundr.push_back(-1);
-                       		 LOG(INFO)<<"inserted -1 in the vector";
-                       		 }
-                 else{
-                       		 LOG(INFO)<<"memory capacity";   
-                       		 roundr.push_back(k);
-                       		 LOG(INFO)<<"pushed back: "<< k;
-			       	}
-
-	
- 	 }
-	}
+  LOG(INFO) << "made the last key to an integer";
+  for (int j = mm; j < (mm + amountEPNs); j++) {
+    LOG(INFO) << "inside the for loop";
+    if (j <= numEPNS) {
+      if (history[prevKeyInt].at(j - 1).memVal == 0) {  // case that it's either zero or broken
+        LOG(INFO) << "no memory capacity";
+        roundr.push_back(-1);
+        LOG(INFO) << "inserted -1 in the vector";
+      } else {
+        LOG(INFO) << "memory capacity";
+        roundr.push_back(j);
+        LOG(INFO) << "pushed back: " << j;
+      }
+    } else {
+      int k = j % numEPNS;
+      if (history[prevKeyInt].at(k - 1).memVal == 0) {  // case that it's either zero or broken
+        LOG(INFO) << "no memory capacity";
+        roundr.push_back(-1);
+        LOG(INFO) << "inserted -1 in the vector";
+      } else {
+        LOG(INFO) << "memory capacity";
+        roundr.push_back(k);
+        LOG(INFO) << "pushed back: " << k;
+      }
+    }
+  }
   return roundr;
-
 }
 
+scheduler::~scheduler() {}
 
-
-
-
-
-scheduler::~scheduler()
-{
-
-
-}
-
-}//namespace SCHEDULER_FLP_EPN
+}  // namespace SCHEDULER_FLP_EPN

--- a/examples/SCHEDULER-FLP-EPN/scheduler.h
+++ b/examples/SCHEDULER-FLP-EPN/scheduler.h
@@ -8,83 +8,75 @@
 #ifndef FAIRMQEXAMPLESCHEDULERFLPEPNSCHEDULER_H
 #define FAIRMQEXAMPLESCHEDULERFLPEPNSCHEDULER_H
 
+#include <chrono>
+#include <map>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
 #include "FairMQDevice.h"
 #include "Message.h"
-#include <string>
-#include <map>
-#include <vector>
-#include <chrono>
-#include <thread>
-#include <sstream>
 
-namespace example_SCHEDULER_FLP_EPN
-{
+namespace example_SCHEDULER_FLP_EPN {
 
-class scheduler : public FairMQDevice
-{
-  public:
-    scheduler();
-    virtual ~scheduler();
-    void sender(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum);
+class scheduler : public FairMQDevice {
+ public:
+  scheduler();
+  virtual ~scheduler();
+  void sender(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum);
 
+ protected:
+  // for EPN SCHEDULER DEALING
+  struct EpnInfo {
+    uint64_t ts = 0;
+    uint64_t memVal = 0;
+  };
+  std::map<uint64_t, std::vector<EpnInfo> > history;
+  uint64_t numEPNS;
+  uint64_t numFLPS;
+  const unsigned intMs;
+  uint64_t programTime;
+  const unsigned historyMaxMs;
 
-  protected:
-  //for EPN SCHEDULER DEALING
-    struct EpnInfo {uint64_t ts = 0; uint64_t memVal = 0;};
-    std::map<uint64_t,std::vector<EpnInfo> > history;
-    uint64_t numEPNS;
-    uint64_t numFLPS;
-    const unsigned intMs;
-    uint64_t programTime;
-    const unsigned historyMaxMs;
+  // constants to generate array sent to FLPs
+  const unsigned msBetweenSubtimeframes;  // the amount of subtimeframes the FLPs send to the EPNs per second
+  uint64_t amountEPNs;       // amount of EPNs that are in the array the Scheduler needs to send to the FLPs
+  const float intervalFLPs;  // the interval in seconds in which the scheduler needs to send array to all FLPs
 
+  // for SCHEDULER FLP DEALING
+  std::vector<uint64_t> vectorForFlps;
+  std::stringstream availableEpns1;
+  std::stringstream EpnsInSchedule1;
+  std::stringstream heatdata1;
 
-       //constants to generate array sent to FLPs
-    const unsigned msBetweenSubtimeframes; //the amount of subtimeframes the FLPs send to the EPNs per second
-    uint64_t amountEPNs; //amount of EPNs that are in the array the Scheduler needs to send to the FLPs
-    const float intervalFLPs; // the interval in seconds in which the scheduler needs to send array to all FLPs
+  // needed for history processing
+  uint64_t tooOld;                 // key which is tooOld (timestamp)
+  uint64_t keyForToFile;           // reference key for writing history to File
+  uint64_t keyForGeneratingArray;  // reference key for generating the array
+  uint64_t keyForExiting;
+  uint64_t scheduleNumber;
+  int m;
 
-  //for SCHEDULER FLP DEALING
-    std::vector<uint64_t> vectorForFlps; 
-    std::stringstream availableEpns1;
-    std::stringstream EpnsInSchedule1;
-    std::stringstream heatdata1;
+  std::thread senderThread(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum);
 
-
-
-    //needed for history processing
-    uint64_t tooOld; //key which is tooOld (timestamp)
-    uint64_t keyForToFile; // reference key for writing history to File
-    uint64_t keyForGeneratingArray; //reference key for generating the array
-    uint64_t keyForExiting;
-    uint64_t scheduleNumber;
-    int m;
-
-    std::thread senderThread(std::vector<uint64_t>* vec, uint64_t* num, uint64_t* numE, uint64_t* schedNum);
-
-
-
-    virtual bool ConditionalRun() override;
-    virtual void InitTask() override;
-    uint64_t getHistKey();
-    void initialize(uint64_t numEPNs);
-    void printHist();
-    void update(uint64_t epnId, uint64_t myMem);
-    void toFile();
-    //what I want to return in this function is a pointer to the first element of the array
-    std::vector<uint64_t> generateSchedule();
-    std::vector<int> generateArray1();
-    int maxSearch(std::vector<int> &arr); // find the EPN with the most free memory, returns the index of the EPN with most free memory
-    void printVecFLP(std::vector<uint64_t> a);
-    void printfreeSlots(int arr[], int length);
-    int availableEpns(const std::vector<int> &arr, uint64_t siz) const;
-    int EpnsInSchedule(int avaiable, uint64_t siz);
-    std::vector<uint64_t> simpleRRSched(int m); //function to print the array that will be sent to all FLPs
-
-
-
+  virtual bool ConditionalRun() override;
+  virtual void InitTask() override;
+  uint64_t getHistKey();
+  void initialize(uint64_t numEPNs);
+  void printHist();
+  void update(uint64_t epnId, uint64_t myMem);
+  void toFile();
+  // what I want to return in this function is a pointer to the first element of the array
+  std::vector<uint64_t> generateSchedule();
+  std::vector<int> generateArray1();
+  int maxSearch(std::vector<int>& arr);  // find the EPN with the most free memory, returns the index of the EPN with
+                                         // most free memory
+  void printVecFLP(std::vector<uint64_t> a);
+  void printfreeSlots(int arr[], int length);
+  int availableEpns(const std::vector<int>& arr, uint64_t siz) const;
+  int EpnsInSchedule(int avaiable, uint64_t siz);
+  std::vector<uint64_t> simpleRRSched(int m);  // function to print the array that will be sent to all FLPs
 };
-
 }
 
 #endif /* FAIRMQEXAMPLESCHEDULERFLPEPNSCHEDULER_H */


### PR DESCRIPTION
small sanity check for sending thread using a mutex to ensure the zeromq interface is not misused.
(see if this helps with the large config)

... and
used `clang-format` tool to format the source for readability:
`clang-format-3.9 -style="{BasedOnStyle: Google, ColumnLimit: 119}" -i *.h *.cxx`

... updated conf script to use IPoIB interfaces (no functional changes, just more efficient transport)